### PR TITLE
🔧 refactor: Updated workflows and dependencies for Laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push:
-    branches: [main]
+    branches: [3.x]
   pull_request:
-    branches: [main]
+    branches: [3.x]
 
 jobs:
   test:
@@ -13,13 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [10.*]
+        php: [8.3, 8.2]
+        laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+          - laravel: 11.*
+            testbench: 9.*
+            carbon: ^3.0
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.3, 8.2]
         laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "touhidurabir/laravel-stub-generator": "^1.0"
@@ -35,7 +35,8 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpunit/phpunit": "^10.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,14 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "touhidurabir/laravel-stub-generator": "^1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "nunomaduro/collision": "^7.9",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^7.10|^8.0",
+        "nunomaduro/larastan": "^2.1.1",
+        "orchestra/testbench": "^v8.22|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/src/PolicyGeneratorServiceProvider.php
+++ b/src/PolicyGeneratorServiceProvider.php
@@ -58,9 +58,7 @@ class PolicyGeneratorServiceProvider extends PackageServiceProvider
         }
     }
 
-    public function packageRegistered(): void
-    {
-    }
+    public function packageRegistered(): void {}
 
     public function packageBooted(): void
     {
@@ -88,7 +86,7 @@ class PolicyGeneratorServiceProvider extends PackageServiceProvider
         }
 
         // Testing
-        Testable::mixin(new TestsPolicyGenerator());
+        Testable::mixin(new TestsPolicyGenerator);
     }
 
     protected function getAssetPackageName(): ?string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,8 +10,6 @@ use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
-use Filament\SpatieLaravelSettingsPluginServiceProvider;
-use Filament\SpatieLaravelTranslatablePluginServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
@@ -43,8 +41,6 @@ class TestCase extends Orchestra
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
-            SpatieLaravelSettingsPluginServiceProvider::class,
-            SpatieLaravelTranslatablePluginServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
Updated CI workflows to include Laravel 11 and PHP 8.3, and adjusted dependencies accordingly.