### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push:
-    branches: [3.x]
+    branches: [4.x]
   pull_request:
-    branches: [3.x]
+    branches: [4.x]
 
 jobs:
   test:
@@ -13,21 +13,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 12.*
+          - php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.0
+          - php: 8.4
+            laravel: 12.*
             testbench: 10.*
             carbon: ^3.0
-          - laravel: 11.*
+          - php: 8.3
+            laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
-        exclude:
-          - laravel: 12.*
-            php: 8.3
-          - laravel: 11.*
-            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,15 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^4.0|^5.0",
-        "spatie/laravel-package-tools": "^1.15.0",
-        "touhidurabir/laravel-stub-generator": "^1.0"
+        "illuminate/filesystem": "^11.28|^12.0|^13.0",
+        "illuminate/support": "^11.28|^12.0|^13.0",
+        "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
         "larastan/larastan": "^2|^3",
         "laravel/pint": "^1.13",
         "nunomaduro/collision": "^7.10|^8.0",
-        "orchestra/testbench": "^8.22|^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^3.0|^4.0",

--- a/src/PolicyGenerator.php
+++ b/src/PolicyGenerator.php
@@ -12,7 +12,7 @@ use function Laravel\Prompts\info;
 
 class PolicyGenerator
 {
-    public static function generateAll(bool $overwrite = false): void
+    public static function generateAll(bool $overwrite = false)
     {
         $resources = Filament::getResources();
 
@@ -78,7 +78,7 @@ class PolicyGenerator
     /**
      * @param  array<string, string>  $replacements
      */
-    protected static function renderStub(string $stub, array $replacements): string
+    private static function renderStub(string $stub, array $replacements): string
     {
         $placeholders = array_map(
             fn (string $placeholder): string => '{{' . $placeholder . '}}',

--- a/src/PolicyGenerator.php
+++ b/src/PolicyGenerator.php
@@ -3,18 +3,19 @@
 namespace ChrisReedIO\PolicyGenerator;
 
 use Filament\Facades\Filament;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
-use Touhidurabir\StubGenerator\Facades\StubGenerator;
 
+use function app;
 use function config;
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\warning;
 
 class PolicyGenerator
 {
-    public static function generateAll(bool $overwrite = false)
+    public static function generateAll(bool $overwrite = false): void
     {
         $resources = Filament::getResources();
+
         foreach ($resources as $resource) {
             self::generate($resource, $overwrite);
         }
@@ -27,7 +28,6 @@ class PolicyGenerator
             return false;
         }
 
-        // Prepare to populate the stub
         $model = $resource::getModel();
         $modelName = class_basename($model);
         $policyName = $modelName . 'Policy';
@@ -36,24 +36,22 @@ class PolicyGenerator
         $destPath = base_path('app/Policies/');
 
         info("Generating {$policyName}...");
-        // Load the stub's placeholders
+
         $replacements = [
             'Namespace' => config('policy-generator.namespace', 'App'),
             'UserModel' => config('policy-generator.user_model', 'App\Models\User'),
             'PolicyModel' => $model,
             'Model' => $modelName,
-            // 'modelVariable' => lcfirst($modelName),
             'permissionModelVariable' => Str::snake($modelName),
             'modelVariable' => lcfirst($modelName),
         ];
 
-        // Generate the policy
-        StubGenerator::from($stubFile, true) // the stub file path
-            ->to($destPath, true, true) // the store directory path
-            ->as($policyName) // the generatable file name without extension
-            ->replace($overwrite) // to replace the file if already exist // TODO - Check if it exists and ask to overwrite
-            ->withReplacers($replacements) // the stub replacing params
-            ->save(); // save the file
+        $filesystem = app(Filesystem::class);
+        $filesystem->ensureDirectoryExists($destPath);
+        $filesystem->put(
+            $destPath . $policyName . '.php',
+            self::renderStub($filesystem->get($stubFile), $replacements),
+        );
 
         return true;
     }
@@ -75,5 +73,18 @@ class PolicyGenerator
         $destPath = base_path('app/Policies/');
 
         return file_exists($destPath . $policyName . '.php');
+    }
+
+    /**
+     * @param  array<string, string>  $replacements
+     */
+    protected static function renderStub(string $stub, array $replacements): string
+    {
+        $placeholders = array_map(
+            fn (string $placeholder): string => '{{' . $placeholder . '}}',
+            array_keys($replacements),
+        );
+
+        return str_replace($placeholders, array_values($replacements), $stub);
     }
 }

--- a/tests/PolicyGeneratorTest.php
+++ b/tests/PolicyGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use ChrisReedIO\PolicyGenerator\PolicyGenerator;
+use Illuminate\Filesystem\Filesystem;
+
+final class ArticleModel {}
+
+final class ArticleResource
+{
+    public static function getModel(): string
+    {
+        return ArticleModel::class;
+    }
+}
+
+it('generates a policy using Laravel filesystem services', function () {
+    config()->set('policy-generator.namespace', 'Testing');
+    config()->set('policy-generator.user_model', 'App\Models\Administrator');
+
+    $generated = PolicyGenerator::generate(ArticleResource::class);
+    $policyPath = base_path('app/Policies/ArticleModelPolicy.php');
+    $policy = file_get_contents($policyPath);
+
+    expect($generated)->toBeTrue()
+        ->and($policyPath)->toBeFile()
+        ->and($policy)
+        ->toContain('namespace Testing\Policies;')
+        ->toContain('use App\Models\Administrator;')
+        ->toContain('use ArticleModel;')
+        ->toContain('view_any::article_model')
+        ->not->toContain('{{');
+});
+
+it('preserves an existing policy unless overwrite is requested', function () {
+    $policyPath = base_path('app/Policies/ArticleModelPolicy.php');
+
+    app(Filesystem::class)->ensureDirectoryExists(dirname($policyPath));
+    file_put_contents($policyPath, 'existing policy');
+
+    expect(PolicyGenerator::generate(ArticleResource::class))->toBeFalse()
+        ->and(file_get_contents($policyPath))->toBe('existing policy')
+        ->and(PolicyGenerator::generate(ArticleResource::class, overwrite: true))->toBeTrue()
+        ->and(file_get_contents($policyPath))->not->toBe('existing policy');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,22 +14,40 @@ use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Filesystem\Filesystem;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 
 class TestCase extends Orchestra
 {
+    protected string $originalBasePath;
+
+    protected string $temporaryBasePath;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->originalBasePath = $this->app->basePath();
+        $this->temporaryBasePath = sys_get_temp_dir() . '/filament-policy-generator-' . bin2hex(random_bytes(8));
+        $this->app->setBasePath($this->temporaryBasePath);
 
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'ChrisReedIO\\PolicyGenerator\\Database\\Factories\\' . class_basename($modelName) . 'Factory'
         );
     }
 
-    protected function getPackageProviders($app)
+    protected function tearDown(): void
+    {
+        $this->app->setBasePath($this->originalBasePath);
+
+        (new Filesystem)->deleteDirectory($this->temporaryBasePath);
+
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app): array
     {
         return [
             ActionsServiceProvider::class,
@@ -48,7 +66,7 @@ class TestCase extends Orchestra
         ];
     }
 
-    public function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app): void
     {
         config()->set('database.default', 'testing');
 


### PR DESCRIPTION
## Summary
- remove the Laravel 12-limited `touhidurabir/laravel-stub-generator` dependency
- generate policies with Laravel filesystem services while preserving existing behavior
- add Laravel 13 / Testbench 11 to the CI matrix and target the active `4.x` branch
- add focused coverage for generation and overwrite behavior

## Validation
- `vendor/bin/pint --dirty`
- `vendor/bin/pest --no-coverage --compact` (4 tests, 15 assertions)
- `vendor/bin/phpstan analyse --no-progress`
- `composer validate --strict`
- `composer audit --locked`
- lowest-dependency dry-runs for Laravel 11 / Testbench 9 and Laravel 12 / Testbench 10
- installed and tested with Laravel 13.23, Filament 5.7, and Livewire 4.3